### PR TITLE
Tweak display of resource-icon in co-section-title

### DIFF
--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -96,6 +96,10 @@ $height: 18px;
   margin-left: 0;
 }
 
+.co-m-resource-icon--flex-child {
+  margin-right: 7px;
+}
+
 .co-m-selector {
   @include co-break-word;
 }

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -228,7 +228,7 @@ export class EnvironmentPage extends PromiseComponent {
     const containerVars = currentEnvVars.map((envVar, i) => {
       const keyString = _.isArray(rawEnvData) ? rawEnvData[i].name : obj.metadata.name;
       return <div key={keyString} className="co-m-pane__body-group">
-        { _.isArray(rawEnvData) && <h1 className="co-section-title"><ResourceIcon kind="Container" className="co-m-resource-icon--align-left co-section-title__resource-icon" /> {keyString}</h1> }
+        { _.isArray(rawEnvData) && <h1 className="co-section-title co-section-title--contains-resource-icon"><ResourceIcon kind="Container" className="co-m-resource-icon--align-left co-m-resource-icon--flex-child" /> {keyString}</h1> }
         <NameValueEditorComponent nameValueId={i} nameValuePairs={envVar} updateParentData={this.updateEnvVars} addString="Add Value" nameString="Name" readOnly={readOnly} allowSorting={true} configMaps={configMaps} secrets={secrets} />
       </div>;
     });

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -101,10 +101,10 @@
   font-size: 20px;
   font-weight: 600;
   margin: 0 0 20px 0;
-}
-
-.co-section-title__resource-icon {
-  vertical-align: 3px;
+  &--contains-resource-icon {
+    align-items: center;
+    display: flex;
+  }
 }
 
 .co-section-title-secondary {


### PR DESCRIPTION
@spadgett, I think I'd do something like this in lieu of vertical-align because it:

* improves the rendering cross browser/platform
* provides a consistent approach (and rendered result) to what's done in co-m-pane__heading at the top of the page [1]

The changes are most noticeable in Firefox on Windows (note:  Firefox does the worst job of Chrome, Safari, and Edge when it comes to the vertical centering of the icon and text)

Before in Firefox on Windows:
![fx-win-before](https://user-images.githubusercontent.com/895728/42884320-0b5265d4-8a6c-11e8-8c63-fcba22492ffc.png)
After in Firefox on Windows:
![fx-win-after](https://user-images.githubusercontent.com/895728/42884321-0d032ae4-8a6c-11e8-9ccf-30f4e2aeeb24.png)

After in Chrome for macOS:
![screen shot 2018-07-18 at 9 26 00 am](https://user-images.githubusercontent.com/895728/42884555-a716af52-8a6c-11e8-8c28-d99810353a35.PNG)

[1] ![screen shot 2018-07-18 at 9 23 33 am](https://user-images.githubusercontent.com/895728/42884420-491fea08-8a6c-11e8-83e4-d268b64a46e0.PNG)

attn: @sg00dwin, your heading changes will impact this, but it should be easy enough to move `&--contains-resource-icon` to your new secondary heading rule. 


