### PR TITLE
YAML Language Server working in Openshift Console

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "clean": "rm -rf ./public/dist",
-    "dev": "yarn clean && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode development --watch --progress",
-    "build": "yarn clean && NODE_ENV=production ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production",
+    "dev": "yarn clean && NODE_OPTIONS=--max-old-space-size=4096 ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode development --watch --progress",
+    "build": "yarn clean && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production",
     "coverage": "jest --coverage .",
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx --color",
     "lint": "yarn eslint .",
@@ -87,6 +87,7 @@
     "js-yaml": "^3.13.1",
     "lodash-es": "4.x",
     "memoize-one": "5.x",
+    "monaco-languageclient": "^0.9.0",
     "murmurhash-js": "1.0.x",
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.59.1",
@@ -120,8 +121,10 @@
     "typesafe-actions": "^4.2.1",
     "url-polyfill": "^1.1.5",
     "url-search-params-polyfill": "2.x",
+    "vscode-languageserver-types": "^3.10.0",
     "whatwg-fetch": "2.x",
     "xterm": "^3.12.2",
+    "yaml-language-server": "0.5.2",
     "yup": "^0.27.0"
   },
   "devDependencies": {
@@ -163,6 +166,7 @@
     "jest": "21.x",
     "jest-cli": "21.x",
     "mini-css-extract-plugin": "0.4.x",
+    "monaco-editor-core": "0.14.0",
     "monaco-editor-webpack-plugin": "^1.7.0",
     "node-sass": "4.8.x",
     "protractor": "5.4.x",

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -13,6 +13,12 @@ import { ExploreTypeSidebar } from './sidebars/explore-type-sidebar';
 import { ResourceSidebar } from './sidebars/resource-sidebar';
 import { yamlTemplates } from '../models/yaml-templates';
 
+import { getStoredSwagger } from '../module/k8s/swagger';
+import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from 'monaco-languageclient/lib/monaco-converter';
+import { getLanguageService, TextDocument, SchemaRequestService, CustomFormatterOptions } from "yaml-language-server";
+import { OpenAPItoJSONSchema } from '../module/k8s/openapi-to-json-schema';
+import * as URL from 'url';
+
 const generateObjToLoad = (kind, templateName, namespace = 'default') => {
   const sampleObj = safeLoad(yamlTemplates.getIn([kind, templateName]));
   if (_.has(sampleObj.metadata, 'namespace')) {
@@ -118,9 +124,10 @@ export const EditYAML = connect(stateToProps)(
       }
     }
 
-    editorDidMount(editor) {
+    editorDidMount(editor, monaco) {
       editor.layout();
       editor.focus();
+      this.registerYAMLinMonaco(monaco);
     }
 
     get editorHeight() {
@@ -312,6 +319,173 @@ export const EditYAML = connect(stateToProps)(
     downloadSampleYaml_(templateName = 'default', kind = referenceForModel(this.props.model)) {
       const data = safeDump(generateObjToLoad(kind, templateName, this.props.obj.metadata.namespace));
       this.download(data);
+    }
+
+    registerYAMLinMonaco(monaco) {
+        const LANGUAGE_ID = 'yaml';
+        const MODEL_URI = 'inmemory://model.yaml'
+        const MONACO_URI = monaco.Uri.parse(MODEL_URI);
+        
+        const m2p = new MonacoToProtocolConverter();
+        const p2m = new ProtocolToMonacoConverter();
+
+        function createDocument(model) {
+            return TextDocument.create(MODEL_URI, model.getModeId(), model.getVersionId(), model.getValue());
+        }
+
+        const yamlService = this.createYAMLService();
+
+        // validation is not a 'registered' feature like the others, it relies on calling the yamlService
+        // directly for validation results when content in the editor has changed
+        this.YAMLValidation(monaco, p2m, MONACO_URI, createDocument, yamlService);
+
+        /**
+         * This exists because react-monaco-editor passes the same monaco
+         * object each time. Without it you would be registering all the features again and
+         * getting duplicate results.
+         * 
+         * Monaco does not provide any apis for unregistering or checking if the features have already
+         * been registered for a language.
+         * 
+         * We check that > 1 YAML language exists because one is the default and one is the initial register
+         * that setups our features. 
+         */
+        if (monaco.languages.getLanguages().filter(x => x.id === LANGUAGE_ID).length > 1) {
+            return;
+        }
+
+        this.registerYAMLLanguage(); //register the YAML language with monaco
+        this.registerYAMLCompletion(LANGUAGE_ID, monaco, m2p, p2m, createDocument, yamlService);
+        this.registerYAMLDocumentSymbols(LANGUAGE_ID, monaco, p2m, createDocument, yamlService);
+        this.registerYAMLHover(LANGUAGE_ID, monaco, m2p, p2m, createDocument, yamlService);
+
+    }
+
+    registerYAMLLanguage() {
+        // register the YAML language with Monaco
+        monaco.languages.register({
+            id: 'yaml',
+            extensions: ['.yml', '.yaml'],
+            aliases: ['YAML', 'yaml'],
+            mimetypes: ['application/yaml']
+        });
+    }
+
+    createYAMLService() {
+        var resolveSchema = function (url) {
+            const promise = new Promise((resolve, reject) => {
+                const xhr = new XMLHttpRequest();
+                xhr.onload = () => resolve(xhr.responseText);
+                xhr.onerror = () => reject(xhr.statusText);
+                xhr.open("GET", url, true);
+                xhr.send();
+            });
+            return promise;
+        }
+
+        const workspaceContext = {
+            resolveRelativePath: (relativePath, resource) => URL.resolve(resource, relativePath)
+        };
+
+        const yamlService = getLanguageService(resolveSchema, workspaceContext, []);
+        
+        // Prepare the schema
+        const yamlOpenAPI = getStoredSwagger();
+
+        // Convert the openAPI schema to something the language server understands
+        const kubernetesJSONSchema = OpenAPItoJSONSchema(yamlOpenAPI);
+
+        const schemas = [{
+            uri: 'inmemory:yaml',
+            fileMatch: ["*"],
+            schema: kubernetesJSONSchema
+        }];
+        yamlService.configure({
+            validate: true,
+            schemas: schemas,
+            hover: true,
+            completion: true
+        });
+        return yamlService;
+    }
+
+    registerYAMLCompletion(languageID, monaco, m2p, p2m, createDocument, yamlService) {
+        monaco.languages.registerCompletionItemProvider(languageID, {
+            provideCompletionItems(model, position, token) {
+                const document = createDocument(model);
+                return yamlService.doComplete(document, m2p.asPosition(position.lineNumber, position.column), true).then((list) => {
+                    return p2m.asCompletionResult(list);
+                });
+            },
+
+            resolveCompletionItem(item, token) {
+                return yamlService.doResolve(m2p.asCompletionItem(item)).then(result => p2m.asCompletionItem(result));
+            }
+        });
+    }
+
+    registerYAMLDocumentSymbols(languageID, monaco, p2m, createDocument, yamlService) {
+        monaco.languages.registerDocumentSymbolProvider(languageID, {
+            provideDocumentSymbols(model, token) {
+                const document = createDocument(model);
+                return p2m.asSymbolInformations(yamlService.findDocumentSymbols(document));
+            }
+        });
+    }
+
+    registerYAMLHover(languageID, monaco, m2p, p2m, createDocument, yamlService) {
+        monaco.languages.registerHoverProvider(languageID, {
+            provideHover(model, position, token) {
+                const document = createDocument(model);
+                return yamlService.doHover(document, m2p.asPosition(position.lineNumber, position.column)).then((hover) => {
+                    return p2m.asHover(hover);
+                });
+            }
+        });
+    }
+
+    YAMLValidation(monaco, p2m, monaco_uri, createDocument, yamlService) {
+        const pendingValidationRequests = new Map();
+
+        function getModel() {
+            return monaco.editor.getModels()[0];
+        }
+
+        getModel().onDidChangeContent((event) => {
+            validate();
+        });
+
+        function validate() {
+            const document = createDocument(getModel());
+            cleanPendingValidation(document);
+            pendingValidationRequests.set(document.uri, setTimeout(() => {
+                pendingValidationRequests.delete(document.uri);
+                doValidate(document);
+            }));
+        }
+
+        function cleanPendingValidation(document) {
+            const request = pendingValidationRequests.get(document.uri);
+            if (request !== undefined) {
+                clearTimeout(request);
+                pendingValidationRequests.delete(document.uri);
+            }
+        }
+
+        function doValidate(document) {
+            if (document.getText().length === 0) {
+                cleanDiagnostics();
+                return;
+            }
+            yamlService.doValidation(document, true).then((diagnostics) => {
+                const markers = p2m.asDiagnostics(diagnostics);
+                monaco.editor.setModelMarkers(getModel(), 'default', markers);
+            });
+        }
+
+        function cleanDiagnostics() {
+            monaco.editor.setModelMarkers(monaco.editor.getModel(monaco_uri), 'default', []);
+        }
     }
 
     render() {

--- a/frontend/public/module/k8s/openapi-to-json-schema.ts
+++ b/frontend/public/module/k8s/openapi-to-json-schema.ts
@@ -1,0 +1,115 @@
+// contains all the relevant information for transforming openapi specifications (such as kuberneres openapi)
+// to json schemas
+
+interface GroupVersionKind {
+    "kind": string,
+    "version": string,
+    "group": string
+};
+  
+/**
+ * Takes in the stored kubernetes openAPI object and outputs a JSON Schema of the object
+ */
+export function OpenAPItoJSONSchema(openAPI: any) {
+
+    const convertedOpenAPI = convertGroupVersionKindToJSONSchema(openAPI);
+    
+    const oneOfSchemas = [];
+    const openAPIDefinitions = {};
+    for (const schemaProperty in convertedOpenAPI) {
+        if (convertedOpenAPI.hasOwnProperty(schemaProperty)) {
+            openAPIDefinitions[schemaProperty] = convertedOpenAPI[schemaProperty];
+            oneOfSchemas.push(
+                {
+                    "$ref": '#/definitions/'+schemaProperty
+                }
+            );
+        }
+    }
+
+    return {
+        "definitions": {
+            ...openAPIDefinitions
+        },
+        "oneOf": oneOfSchemas
+    };
+}
+
+/**
+ * Converts the openAPI kubernetes specification for group, version, kind to JSON Schema
+ * 
+ * Context: The openAPI specification gives the group, version, and kind objects as 'x-kubernetes-group-version-kind'
+ * instead of adding the values to the enum's
+ */
+function convertGroupVersionKindToJSONSchema(openAPI: any) {
+    for (const definition in openAPI) {
+        if (openAPI.hasOwnProperty(definition)) {
+            const openAPIDefinition = openAPI[definition];
+            const groupVersionKind = openAPIDefinition['x-kubernetes-group-version-kind'];
+
+            // If this object has x-kubernetes-group-version-kind then add their values into correct places in JSON Schema
+            if (groupVersionKind) {
+                const gvkEnums = groupVersionKindToEnums(groupVersionKind);
+                createOrAppendAPIVersion(openAPIDefinition['properties'], gvkEnums.versionEnum);
+                createOrAppendKind(openAPIDefinition['properties'], gvkEnums.kindEnum);
+            }
+        }
+    }
+    return openAPI;
+}
+
+/**
+ * Given an array of GroupVersionKind objects, return their JSON Schema representation as enums
+ */
+function groupVersionKindToEnums(gvkObjArray: [GroupVersionKind]) {
+    const versionEnum = [];
+    const kindEnum = []; 
+    for (const gvkObj of gvkObjArray) {
+        if (gvkObj.group && gvkObj.version) {
+            versionEnum.push(gvkObj.group + "/" + gvkObj.version);
+        } else if (gvkObj.version) {
+            versionEnum.push(gvkObj.version);
+        }
+        if (gvkObj.kind) {
+            kindEnum.push(gvkObj.kind);
+        }
+    }
+    return {
+        versionEnum,
+        kindEnum
+    }
+}
+
+/**
+ * Append enums to APIVersion or create the object if it doesn't exist
+ */
+function createOrAppendAPIVersion(openAPI: any, apiVersionEnum: string[]) {
+    if (openAPI['apiVersion']) {
+        if(openAPI['apiVersion'].enum){
+            openAPI['apiVersion'].enum.push(...apiVersionEnum);
+        } else {
+            openAPI['apiVersion'].enum = apiVersionEnum;
+        }
+    } else {
+        openAPI['apiVersion'] = {
+            enum: apiVersionEnum
+        }
+    }
+}
+
+/**
+ * Append enums to kind or create the object if it doesn't exist
+ */
+function createOrAppendKind(openAPI: any, kindEnum: string[]) {
+    if (openAPI['kind']) {
+        if(openAPI['kind'].enum){
+            openAPI['kind'].enum.push(...kindEnum);
+        } else {
+            openAPI['kind'].enum = kindEnum;
+        }
+    } else {
+        openAPI['kind'] = {
+            enum: kindEnum
+        }
+    }
+}

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -16,7 +16,7 @@ const NODE_ENV = process.env.NODE_ENV;
 const extractCSS = new MiniCssExtractPlugin({filename: 'app-bundle.css'});
 
 const config: webpack.Configuration = {
-  entry: ['./polyfills.js', '@console/app'],
+  entry: ['./polyfills.js', '@console/app', 'monaco-editor-core/esm/vs/editor/editor.worker.js'],
   output: {
     path: path.resolve(__dirname, 'public/dist'),
     publicPath: 'static/',
@@ -28,6 +28,10 @@ const config: webpack.Configuration = {
   },
   node: {
     fs: 'empty',
+    child_process: 'empty',
+    net: 'empty',
+    crypto: 'empty',
+    module: 'empty'
   },
   module: {
     rules: [

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -952,6 +952,13 @@ adm-zip@^0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.7.tgz#8606c2cbf1c426ce8c8ec00174447fd49b6eafc1"
 
+agent-base@4:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
 agent-base@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
@@ -3820,6 +3827,12 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
+debug@3.1.0, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 debug@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
@@ -3832,12 +3845,6 @@ debug@^3.0.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  dependencies:
-    ms "2.0.0"
 
 debug@^4.0.1:
   version "4.1.1"
@@ -5494,6 +5501,11 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
 glob2base@^0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
@@ -6089,6 +6101,14 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
+
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -7261,6 +7281,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonc-parser@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.1.0.tgz#eb0d0c7a3c33048524ce3574c57c7278fb2f1bf3"
+  integrity sha512-n9GrT8rrr2fhvBbANa1g+xFmgGK5X91KFeDwlKQ3+SJfmH5+tKv/M/kahx/TXOMflfWHKGKqKyfHQaLKTNzJ6w==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -8103,6 +8128,11 @@ moment-timezone@^0.4.0, moment-timezone@^0.4.1:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
+monaco-editor-core@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor-core/-/monaco-editor-core-0.14.0.tgz#8967e5cabc929e963c954717c089694c0ea43def"
+  integrity sha512-dshMCX73ncl25D3hgFLNPYy0159ePHl4I4+x6iY01KJ3SDaoXQGIvlcvJmi6gEdSndUMRbyttdnQ4aXm2rx2KQ==
+
 monaco-editor-webpack-plugin@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.7.0.tgz#920cbeecca25f15d70d568a7e11b0ba4daf1ae83"
@@ -8114,6 +8144,16 @@ monaco-editor@^0.14.2:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.14.3.tgz#7cc4a4096a3821f52fea9b10489b527ef3034e22"
   integrity sha512-RhaO4xXmWn/p0WrkEOXe4PoZj6xOcvDYjoAh0e1kGUrQnP1IOpc0m86Ceuaa2CLEMDINqKijBSmqhvBQnsPLHQ==
+
+monaco-languageclient@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.9.0.tgz#4b65684e277edab07625e76eb3d3d93e8f2130fa"
+  integrity sha512-N8IdHUnV8Sq2nfm3dSZ0SpILmGhqrTvdXkL0BFfJvV2vcKYVVQ36AXJNqCRImmovkeNUHLyQMeHTqOwvMMVxCQ==
+  dependencies:
+    glob-to-regexp "^0.3.0"
+    vscode-base-languageclient "4.4.0"
+    vscode-jsonrpc "^3.6.2"
+    vscode-uri "^1.0.5"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -9433,6 +9473,11 @@ prettier@1.17.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
   integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
 
+prettier@^1.17.1:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 prettier@^1.5.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
@@ -10472,6 +10517,15 @@ replace-ext@0.0.1:
 replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+
+request-light@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.2.4.tgz#3cea29c126682e6bcadf7915353322eeba01a755"
+  integrity sha512-pM9Fq5jRnSb+82V7M97rp8FE9/YNeP2L9eckB4Szd7lyeclSIx02aIpPO/6e4m6Dy31+FBN/zkFMTd2HkNO3ow==
+  dependencies:
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    vscode-nls "^4.0.0"
 
 request-promise-core@1.1.2:
   version "1.1.2"
@@ -12629,6 +12683,69 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vscode-base-languageclient@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-base-languageclient/-/vscode-base-languageclient-4.4.0.tgz#07098fe42a986e8b65e47960de5ccf656aefe8d0"
+  integrity sha512-FUlMRslHaVCZZ4pSmLqa7p04yuB5hUSgqFAx5W4uINB9RfKgoTyy6eUphuhIsdBzgME1gyLe212Z8thmNNCy1A==
+  dependencies:
+    vscode-languageserver-protocol "^3.10.0"
+
+vscode-json-languageservice@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.2.0.tgz#fe796c2ddbda966d87905442f9636f139e00f341"
+  integrity sha512-tLAv9/D01fLAvnYnZ1OLy03HSHhVFjaSkUidEjfrwytHrxVDgqXLkHAJg+F6Q3mPYfpnPQvN2jTjiJ1yInuNVg==
+  dependencies:
+    jsonc-parser "^2.0.2"
+    vscode-languageserver-types "^3.13.0"
+    vscode-nls "^4.0.0"
+    vscode-uri "^1.0.6"
+
+vscode-jsonrpc@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz#3b5eef691159a15556ecc500e9a8a0dd143470c8"
+  integrity sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA==
+
+vscode-jsonrpc@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
+  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+
+vscode-languageserver-protocol@3.14.1, vscode-languageserver-protocol@^3.10.0:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
+  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
+  dependencies:
+    vscode-jsonrpc "^4.0.0"
+    vscode-languageserver-types "3.14.0"
+
+vscode-languageserver-types@3.14.0, vscode-languageserver-types@^3.10.0, vscode-languageserver-types@^3.13.0, vscode-languageserver-types@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
+  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
+
+vscode-languageserver@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz#0d2feddd33f92aadf5da32450df498d52f6f14eb"
+  integrity sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==
+  dependencies:
+    vscode-languageserver-protocol "3.14.1"
+    vscode-uri "^1.0.6"
+
+vscode-nls@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.1.1.tgz#f9916b64e4947b20322defb1e676a495861f133c"
+  integrity sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A==
+
+vscode-uri@^1.0.5, vscode-uri@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
+  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
+
+vscode-uri@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.0.2.tgz#cbc7982525e1cd102d2da6515e6f103650cb507c"
+  integrity sha512-VebpIxm9tG0fG2sBOhnsSPzDYuNUPP1UQW4K3mwthlca4e4f3d6HKq3HkITC2OPFomOaB7pHTSjcpdFWjfYTzg==
+
 vue-parser@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/vue-parser/-/vue-parser-1.1.6.tgz#3063c8431795664ebe429c23b5506899706e6355"
@@ -13049,6 +13166,25 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yaml-ast-parser-custom-tags@0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz#46968145ce4e24cb03c3312057f0f141b93a7d02"
+  integrity sha512-R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ==
+
+yaml-language-server@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/yaml-language-server/-/yaml-language-server-0.5.2.tgz#dd2e60801b4ae233daac79c37a88e18012221ddb"
+  integrity sha512-DEVMXSXZioXR5q9OJsN1a1jVKxIfHTUZ/wTRy3H5w1M4/e8JV0AosuqQebHcd0FRMTGw2pscLFJ7fp0lLQmQww==
+  dependencies:
+    js-yaml "^3.13.1"
+    prettier "^1.17.1"
+    request-light "^0.2.4"
+    vscode-json-languageservice "3.2.0"
+    vscode-languageserver "^5.2.1"
+    vscode-languageserver-types "^3.14.0"
+    vscode-uri "^2.0.2"
+    yaml-ast-parser-custom-tags "0.0.43"
 
 yargs-parser@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR brings the YAML Language Server into Openshift Console.

Features include:
- Hover based off of schema
- Validation based off of schema
- Auto completion based off of schema
- Document Symbols

Features missing:
- Formatter (currently does not work because prettier does not play well with webpack)
- Schemas for CRD's

The schema is grabbed from the internally stored kubernetes swagger file and converted into a json schema so that the YAML LS can 'understand' it. This converted schema performs better than the one currently built into the YAML LS!

