### PR TITLE
Set the default monaco tab size to be 2

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -130,6 +130,7 @@ export const EditYAML = connect(stateToProps)(
       editor.layout();
       editor.focus();
       this.registerYAMLinMonaco(monaco);
+      monaco.editor.getModels()[0].updateOptions({ tabSize: 2});
     }
 
     get editorHeight() {


### PR DESCRIPTION
This PR sets the default monaco tab size to 2 which is a lot more natural then the previous default of 4