### PR TITLE
Add cluster in url

### DIFF
--- a/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
+++ b/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
@@ -2,7 +2,11 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
-import { setActiveCluster } from '@console/internal/actions/ui';
+import { useLocation } from 'react-router-dom';
+import { setActiveCluster, formatNamespaceRoute } from '@console/internal/actions/ui';
+import { getCluster } from '@console/internal/components/utils/link';
+import { history } from '@console/internal/components/utils/router';
+import { useActiveNamespace } from '@console/shared';
 import { LAST_CLUSTER_USER_SETTINGS_KEY } from '@console/shared/src/constants';
 import { useUserSettings } from '@console/shared/src/hooks/useUserSettings';
 
@@ -28,10 +32,31 @@ export const useValuesForClusterContext = () => {
     [dispatch, setLastCluster],
   );
 
+  const urlCluster = getCluster(useLocation().pathname);
+  const knownCluster = window.SERVER_FLAGS.clusters.includes(urlCluster);
+  const [activeNamespace] = useActiveNamespace();
+
   React.useEffect(() => {
-    // TODO: Detect cluster from URL.
+    if (urlCluster && knownCluster) {
+      setLastCluster(urlCluster);
+    }
     if (lastClusterLoaded && lastCluster) {
       dispatch(setActiveCluster(lastCluster));
+    }
+
+    if (lastClusterLoaded && (!urlCluster || !knownCluster)) {
+      // might require URL change:
+      const newPath = formatNamespaceRoute(
+        activeNamespace,
+        window.location.pathname,
+        window.location,
+        true,
+        lastCluster,
+      );
+
+      if (newPath !== window.location.pathname) {
+        history.pushPath(newPath);
+      }
     }
     // Only run this hook after last cluster is loaded.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -291,6 +291,17 @@ const AppContents: React.FC<{}> = () => {
                   />
                 )}
               />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/alertmanagers/:name"
+                exact
+                render={({ match }) => (
+                  <Redirect
+                    to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
+                      match.params.name
+                    }`}
+                  />
+                )}
+              />
 
               <LazyRoute
                 path="/k8s/all-namespaces/events"
@@ -302,6 +313,16 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/all-namespaces/events"
+                exact
+                loader={() =>
+                  import('./events' /* webpackChunkName: "events" */).then((m) =>
+                    NamespaceFromURL(m.EventStreamPage),
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/events"
                 exact
                 loader={() =>
@@ -310,6 +331,16 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/events"
+                exact
+                loader={() =>
+                  import('./events' /* webpackChunkName: "events" */).then((m) =>
+                    NamespaceFromURL(m.EventStreamPage),
+                  )
+                }
+              />
+
               <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
               <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
               <Route path="/search" exact component={NamespaceRedirect} />
@@ -324,7 +355,26 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/all-namespaces/import"
+                exact
+                loader={() =>
+                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                    NamespaceFromURL(m.ImportYamlPage),
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/import/"
+                exact
+                loader={() =>
+                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                    NamespaceFromURL(m.ImportYamlPage),
+                  )
+                }
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/import/"
                 exact
                 loader={() =>
                   import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
@@ -355,6 +405,17 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/secrets/~new/:type"
+                exact
+                kind="Secret"
+                loader={() =>
+                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                    (m) => m.CreateSecret,
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/secrets/:name/edit"
                 exact
                 kind="Secret"
@@ -365,7 +426,24 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/secrets/:name/edit"
+                exact
+                kind="Secret"
+                loader={() =>
+                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                    (m) => m.EditSecret,
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/secrets/:name/edit-yaml"
+                exact
+                kind="Secret"
+                loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/secrets/:name/edit-yaml"
                 exact
                 kind="Secret"
                 loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
@@ -373,6 +451,16 @@ const AppContents: React.FC<{}> = () => {
 
               <LazyRoute
                 path="/k8s/ns/:ns/networkpolicies/~new/form"
+                exact
+                kind="NetworkPolicy"
+                loader={() =>
+                  import(
+                    '@console/app/src/components/network-policies/create-network-policy' /* webpackChunkName: "create-network-policy" */
+                  ).then((m) => m.CreateNetworkPolicy)
+                }
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/networkpolicies/~new/form"
                 exact
                 kind="NetworkPolicy"
                 loader={() =>
@@ -392,6 +480,16 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/routes/~new/form"
+                exact
+                kind="Route"
+                loader={() =>
+                  import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
+                    (m) => m.CreateRoute,
+                  )
+                }
+              />
 
               <LazyRoute
                 path="/k8s/cluster/rolebindings/~new"
@@ -402,6 +500,15 @@ const AppContents: React.FC<{}> = () => {
                 kind="RoleBinding"
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/cluster/rolebindings/~new"
+                exact
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+                }
+                kind="RoleBinding"
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/rolebindings/~new"
                 exact
                 loader={() =>
@@ -409,6 +516,15 @@ const AppContents: React.FC<{}> = () => {
                 }
                 kind="RoleBinding"
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/rolebindings/~new"
+                exact
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+                }
+                kind="RoleBinding"
+              />
+
               <LazyRoute
                 path="/k8s/ns/:ns/rolebindings/:name/copy"
                 exact
@@ -418,6 +534,15 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/rolebindings/:name/copy"
+                exact
+                kind="RoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/rolebindings/:name/edit"
                 exact
                 kind="RoleBinding"
@@ -425,6 +550,15 @@ const AppContents: React.FC<{}> = () => {
                   import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/rolebindings/:name/edit"
+                exact
+                kind="RoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+                }
+              />
+
               <LazyRoute
                 path="/k8s/cluster/clusterrolebindings/:name/copy"
                 exact
@@ -434,6 +568,15 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/cluster/clusterrolebindings/:name/copy"
+                exact
+                kind="ClusterRoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/cluster/clusterrolebindings/:name/edit"
                 exact
                 kind="ClusterRoleBinding"
@@ -442,7 +585,25 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/cluster/clusterrolebindings/:name/edit"
+                exact
+                kind="ClusterRoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/:plural/:name/attach-storage"
+                exact
+                loader={() =>
+                  import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
+                    (m) => m.default,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural/:name/attach-storage"
                 exact
                 loader={() =>
                   import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
@@ -461,6 +622,16 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/persistentvolumeclaims/~new/form"
+                exact
+                kind="PersistentVolumeClaim"
+                loader={() =>
+                  import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
+                    (m) => m.CreatePVC,
+                  )
+                }
+              />
 
               <LazyRoute
                 path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
@@ -471,9 +642,27 @@ const AppContents: React.FC<{}> = () => {
                   ).then((m) => m.VolumeSnapshot)
                 }
               />
+              <LazyRoute
+                path={`/cluster/:clusterName/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
+                exact
+                loader={() =>
+                  import(
+                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                  ).then((m) => m.VolumeSnapshot)
+                }
+              />
 
               <LazyRoute
                 path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
+                exact
+                loader={() =>
+                  import(
+                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                  ).then((m) => m.VolumeSnapshot)
+                }
+              />
+              <LazyRoute
+                path={`/cluster/:clusterName/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
                 exact
                 loader={() =>
                   import(
@@ -653,20 +842,79 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path={'/cluster/:clusterName/k8s/cluster/storageclasses/~new/form'}
+                exact
+                loader={() =>
+                  import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
+                    (m) => m.StorageClassForm,
+                  )
+                }
+              />
 
+              {/* START of new links */}
               <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/cluster/:plural"
+                exact
+                component={ResourceListPage}
+              />
+
               <Route path="/k8s/cluster/:plural/~new" exact component={CreateResource} />
+              <Route
+                path="/cluster/:clusterName/k8s/cluster/:plural/~new"
+                exact
+                component={CreateResource}
+              />
+
               <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/cluster/:plural/:name"
+                component={ResourceDetailsPage}
+              />
+
               <LazyRoute
                 path="/k8s/ns/:ns/pods/:podName/containers/:name"
                 loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/pods/:podName/containers/:name"
+                loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
+              />
+
               <Route path="/k8s/ns/:ns/:plural/~new" exact component={CreateResource} />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural/~new"
+                exact
+                component={CreateResource}
+              />
+
               <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural/:name"
+                component={ResourceDetailsPage}
+              />
+
               <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural"
+                exact
+                component={ResourceListPage}
+              />
 
               <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/all-namespaces/:plural"
+                exact
+                component={ResourceListPage}
+              />
+
               <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/all-namespaces/:plural/:name"
+                component={ResourceDetailsPage}
+              />
+              {/* END of new links */}
 
               {inactivePluginPageRoutes}
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -204,9 +204,9 @@ class App_ extends React.PureComponent {
     );
 
     return (
-      <DetectCluster>
-        <DetectPerspective>
-          <DetectNamespace>
+      <DetectPerspective>
+        <DetectNamespace>
+          <DetectCluster>
             {contextProviderExtensions.reduce(
               (children, e) => (
                 <EnhancedProvider key={e.uid} {...e.properties}>
@@ -215,9 +215,9 @@ class App_ extends React.PureComponent {
               ),
               content,
             )}
-          </DetectNamespace>
-        </DetectPerspective>
-      </DetectCluster>
+          </DetectCluster>
+        </DetectNamespace>
+      </DetectPerspective>
     );
   }
 }

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -58,7 +58,7 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
     dispatch(clearSSARFlags());
     dispatch(detectFeatures());
     const oldPath = window.location.pathname;
-    const newPath = formatNamespaceRoute(activeNamespace, oldPath, window.location, true);
+    const newPath = formatNamespaceRoute(activeNamespace, oldPath, window.location, true, cluster);
     if (newPath !== oldPath) {
       history.pushPath(newPath);
     }

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -33,6 +33,17 @@ export const namespacedPrefixes = [
 
 export const stripBasePath = (path: string): string => path.replace(basePathPattern, '/');
 
+export const getCluster = (path: string): string => {
+  const strippedPath = stripBasePath(path);
+  const split = strippedPath.split('/').filter((x) => x);
+
+  if (split[0] === 'cluster') {
+    return split[1];
+  }
+
+  return;
+};
+
 export const getNamespace = (path: string): string => {
   path = stripBasePath(path);
   const split = path.split('/').filter((x) => x);


### PR DESCRIPTION
This will place the cluster in the URL for certain routes.

The code is still a little clunky and it taps into the formatNamespaceRoute which allows it to work easier with the cluster selector. This meant that I need to change the `DetectCluster` needs to be inside of `DetectNamespace`.