### PR TITLE
Add cluster in url - Newest cleaned up code

### DIFF
--- a/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
+++ b/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
@@ -8,9 +8,9 @@ import { setActiveCluster, formatNamespaceRoute } from '@console/internal/action
 import { getCluster } from '@console/internal/components/utils/link';
 import { history } from '@console/internal/components/utils/router';
 // import { useActiveNamespace } from '@console/shared';
+import store from '@console/internal/redux';
 import { LAST_CLUSTER_USER_SETTINGS_KEY } from '@console/shared/src/constants';
 import { useUserSettings } from '@console/shared/src/hooks/useUserSettings';
-import store from '../../../../../public/redux';
 
 export const multiClusterRoutePrefixes = ['/k8s/all-namespaces', '/k8s/cluster', '/k8s/ns'];
 
@@ -37,6 +37,8 @@ export const useValuesForClusterContext = () => {
   );
 
   // const [activeNamespace] = useActiveNamespace();
+  //  const activeNamespace = useSelector(({ UI }) => UI.get('activeNamespace'));
+
   const urlCluster = getCluster(useLocation().pathname);
   React.useEffect(() => {
     if (urlCluster) {

--- a/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
+++ b/frontend/packages/console-app/src/components/detect-cluster/cluster.ts
@@ -2,9 +2,17 @@ import * as React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { useDispatch } from 'react-redux';
-import { setActiveCluster } from '@console/internal/actions/ui';
+import { useLocation } from 'react-router-dom';
+import isMultiClusterEnabled from '@console/app/src/utils/isMultiClusterEnabled';
+import { setActiveCluster, formatNamespaceRoute } from '@console/internal/actions/ui';
+import { getCluster } from '@console/internal/components/utils/link';
+import { history } from '@console/internal/components/utils/router';
+// import { useActiveNamespace } from '@console/shared';
 import { LAST_CLUSTER_USER_SETTINGS_KEY } from '@console/shared/src/constants';
 import { useUserSettings } from '@console/shared/src/hooks/useUserSettings';
+import store from '../../../../../public/redux';
+
+export const multiClusterRoutePrefixes = ['/k8s/all-namespaces', '/k8s/cluster', '/k8s/ns'];
 
 type ClusterContextType = {
   cluster?: string;
@@ -28,14 +36,39 @@ export const useValuesForClusterContext = () => {
     [dispatch, setLastCluster],
   );
 
+  // const [activeNamespace] = useActiveNamespace();
+  const urlCluster = getCluster(useLocation().pathname);
   React.useEffect(() => {
-    // TODO: Detect cluster from URL.
-    if (lastClusterLoaded && lastCluster) {
+    if (urlCluster) {
+      setLastCluster(urlCluster);
+      dispatch(setActiveCluster(urlCluster));
+    } else if (lastClusterLoaded && lastCluster) {
       dispatch(setActiveCluster(lastCluster));
     }
-    // Only run this hook after last cluster is loaded.
+
+    if (
+      isMultiClusterEnabled() &&
+      lastClusterLoaded &&
+      lastCluster &&
+      !urlCluster &&
+      multiClusterRoutePrefixes.some((pattern) => window.location.pathname.startsWith(pattern))
+    ) {
+      const activeNamespace = store.getState().UI.get('activeNamespace');
+      const newPath = formatNamespaceRoute(
+        activeNamespace,
+        window.location.pathname,
+        window.location,
+        false,
+        lastCluster,
+      );
+
+      if (newPath !== window.location.pathname) {
+        history.pushPath(newPath);
+      }
+    }
+    // Only run this hook after last cluster is loaded or window path changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lastClusterLoaded]);
+  }, [lastClusterLoaded, urlCluster, window.location.pathname]);
 
   return {
     cluster: lastCluster,

--- a/frontend/packages/console-shared/src/utils/__tests__/user-settings.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/user-settings.spec.ts
@@ -40,7 +40,10 @@ describe('createConfigMap', () => {
 
     expect(actual).toEqual(configMap);
     expect(coFetchMock).toHaveBeenCalledTimes(1);
-    expect(coFetchMock).lastCalledWith('/api/console/user-settings', { method: 'POST' });
+    expect(coFetchMock).lastCalledWith('/api/console/user-settings', {
+      headers: { 'X-Cluster': 'local-cluster' },
+      method: 'POST',
+    });
   });
 });
 
@@ -61,6 +64,7 @@ describe('updateConfigMap', () => {
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/merge-patch+json;charset=UTF-8',
+          'X-Cluster': 'local-cluster',
         },
         body: '{"data":{"key":"value"}}',
       },

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -10,6 +10,7 @@ import {
   ALL_NAMESPACES_KEY,
   LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
 } from '@console/shared/src/constants';
+// import { multiClusterRoutePrefixes } from '@console/app/src/components/detect-cluster/cluster'
 import { K8sResourceKind, PodKind, NodeKind } from '../module/k8s';
 import { allModels } from '../module/k8s/k8s-models';
 import { detectFeatures, clearSSARFlags } from './features';
@@ -152,10 +153,23 @@ export const formatNamespaceRoute = (
   originalPath,
   location?,
   forceList?: boolean,
+  activeCluster?: string,
 ) => {
   let path = originalPath.substr(window.SERVER_FLAGS.basePath.length);
 
   let parts = path.split('/').filter((p) => p);
+
+  if (parts[0] === 'cluster') {
+    // The url pattern that includes the cluster name starts  with /cluster/:clusterName
+    parts.splice(0, 2);
+  }
+
+  const multiClusterRoutePrefixes = ['/k8s/all-namespaces', '/k8s/cluster', '/k8s/ns'];
+  const clusterPathPart =
+    activeCluster && multiClusterRoutePrefixes.includes(`/${parts[0]}/${parts[1]}`)
+      ? `/cluster/${activeCluster}`
+      : '';
+
   const prefix = parts.shift();
 
   let previousNS;
@@ -168,7 +182,7 @@ export const formatNamespaceRoute = (
   }
 
   if (!previousNS) {
-    return originalPath;
+    return `${clusterPathPart}${originalPath}`;
   }
 
   if (
@@ -193,7 +207,7 @@ export const formatNamespaceRoute = (
     path += `${location.search}${location.hash}`;
   }
 
-  return path;
+  return `${clusterPathPart}${path}`;
 };
 
 export const setCurrentLocation = (location: string) =>
@@ -211,6 +225,7 @@ export const setActiveNamespace = (namespace: string = '') => {
   // make it noop when new active namespace is the same
   // otherwise users will get page refresh and cry about
   // broken direct links and bookmarks
+
   if (namespace !== getActiveNamespace()) {
     const oldPath = window.location.pathname;
     const newPath = formatNamespaceRoute(namespace, oldPath, window.location);

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -296,9 +296,9 @@ const AppContents: React.FC<{}> = () => {
                 exact
                 render={({ match }) => (
                   <Redirect
-                    to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
-                      match.params.name
-                    }`}
+                    to={`/cluster/:clusterName/k8s/ns/${match.params.ns}/${referenceForModel(
+                      AlertmanagerModel,
+                    )}/${match.params.name}`}
                   />
                 )}
               />

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -291,6 +291,17 @@ const AppContents: React.FC<{}> = () => {
                   />
                 )}
               />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/alertmanagers/:name"
+                exact
+                render={({ match }) => (
+                  <Redirect
+                    to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
+                      match.params.name
+                    }`}
+                  />
+                )}
+              />
 
               <LazyRoute
                 path="/k8s/all-namespaces/events"
@@ -302,6 +313,16 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/all-namespaces/events"
+                exact
+                loader={() =>
+                  import('./events' /* webpackChunkName: "events" */).then((m) =>
+                    NamespaceFromURL(m.EventStreamPage),
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/events"
                 exact
                 loader={() =>
@@ -310,6 +331,16 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/events"
+                exact
+                loader={() =>
+                  import('./events' /* webpackChunkName: "events" */).then((m) =>
+                    NamespaceFromURL(m.EventStreamPage),
+                  )
+                }
+              />
+
               <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
               <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
               <Route path="/search" exact component={NamespaceRedirect} />
@@ -324,7 +355,26 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/all-namespaces/import"
+                exact
+                loader={() =>
+                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                    NamespaceFromURL(m.ImportYamlPage),
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/import/"
+                exact
+                loader={() =>
+                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                    NamespaceFromURL(m.ImportYamlPage),
+                  )
+                }
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/import/"
                 exact
                 loader={() =>
                   import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
@@ -355,6 +405,17 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/secrets/~new/:type"
+                exact
+                kind="Secret"
+                loader={() =>
+                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                    (m) => m.CreateSecret,
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/secrets/:name/edit"
                 exact
                 kind="Secret"
@@ -365,7 +426,24 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/secrets/:name/edit"
+                exact
+                kind="Secret"
+                loader={() =>
+                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                    (m) => m.EditSecret,
+                  )
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/secrets/:name/edit-yaml"
+                exact
+                kind="Secret"
+                loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/secrets/:name/edit-yaml"
                 exact
                 kind="Secret"
                 loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
@@ -373,6 +451,16 @@ const AppContents: React.FC<{}> = () => {
 
               <LazyRoute
                 path="/k8s/ns/:ns/networkpolicies/~new/form"
+                exact
+                kind="NetworkPolicy"
+                loader={() =>
+                  import(
+                    '@console/app/src/components/network-policies/create-network-policy' /* webpackChunkName: "create-network-policy" */
+                  ).then((m) => m.CreateNetworkPolicy)
+                }
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/networkpolicies/~new/form"
                 exact
                 kind="NetworkPolicy"
                 loader={() =>
@@ -392,6 +480,16 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/routes/~new/form"
+                exact
+                kind="Route"
+                loader={() =>
+                  import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
+                    (m) => m.CreateRoute,
+                  )
+                }
+              />
 
               <LazyRoute
                 path="/k8s/cluster/rolebindings/~new"
@@ -402,6 +500,15 @@ const AppContents: React.FC<{}> = () => {
                 kind="RoleBinding"
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/cluster/rolebindings/~new"
+                exact
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+                }
+                kind="RoleBinding"
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/rolebindings/~new"
                 exact
                 loader={() =>
@@ -409,6 +516,15 @@ const AppContents: React.FC<{}> = () => {
                 }
                 kind="RoleBinding"
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/rolebindings/~new"
+                exact
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+                }
+                kind="RoleBinding"
+              />
+
               <LazyRoute
                 path="/k8s/ns/:ns/rolebindings/:name/copy"
                 exact
@@ -418,6 +534,15 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/rolebindings/:name/copy"
+                exact
+                kind="RoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/rolebindings/:name/edit"
                 exact
                 kind="RoleBinding"
@@ -425,6 +550,15 @@ const AppContents: React.FC<{}> = () => {
                   import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/rolebindings/:name/edit"
+                exact
+                kind="RoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+                }
+              />
+
               <LazyRoute
                 path="/k8s/cluster/clusterrolebindings/:name/copy"
                 exact
@@ -434,6 +568,15 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/cluster/clusterrolebindings/:name/copy"
+                exact
+                kind="ClusterRoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/cluster/clusterrolebindings/:name/edit"
                 exact
                 kind="ClusterRoleBinding"
@@ -442,7 +585,25 @@ const AppContents: React.FC<{}> = () => {
                 }
               />
               <LazyRoute
+                path="/cluster/:clusterName/k8s/cluster/clusterrolebindings/:name/edit"
+                exact
+                kind="ClusterRoleBinding"
+                loader={() =>
+                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+                }
+              />
+
+              <LazyRoute
                 path="/k8s/ns/:ns/:plural/:name/attach-storage"
+                exact
+                loader={() =>
+                  import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
+                    (m) => m.default,
+                  )
+                }
+              />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural/:name/attach-storage"
                 exact
                 loader={() =>
                   import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
@@ -461,6 +622,16 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/persistentvolumeclaims/~new/form"
+                exact
+                kind="PersistentVolumeClaim"
+                loader={() =>
+                  import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
+                    (m) => m.CreatePVC,
+                  )
+                }
+              />
 
               <LazyRoute
                 path={`/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
@@ -471,9 +642,27 @@ const AppContents: React.FC<{}> = () => {
                   ).then((m) => m.VolumeSnapshot)
                 }
               />
+              <LazyRoute
+                path={`/cluster/:clusterName/k8s/ns/:ns/${VolumeSnapshotModel.plural}/~new/form`}
+                exact
+                loader={() =>
+                  import(
+                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                  ).then((m) => m.VolumeSnapshot)
+                }
+              />
 
               <LazyRoute
                 path={`/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
+                exact
+                loader={() =>
+                  import(
+                    '@console/app/src/components/volume-snapshot/create-volume-snapshot/create-volume-snapshot' /* webpackChunkName: "create-volume-snapshot" */
+                  ).then((m) => m.VolumeSnapshot)
+                }
+              />
+              <LazyRoute
+                path={`/cluster/:clusterName/k8s/all-namespaces/${VolumeSnapshotModel.plural}/~new/form`}
                 exact
                 loader={() =>
                   import(
@@ -653,20 +842,79 @@ const AppContents: React.FC<{}> = () => {
                   )
                 }
               />
+              <LazyRoute
+                path={'/cluster/:clusterName/k8s/cluster/storageclasses/~new/form'}
+                exact
+                loader={() =>
+                  import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
+                    (m) => m.StorageClassForm,
+                  )
+                }
+              />
 
+              {/* START of new links */}
               <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/cluster/:plural"
+                exact
+                component={ResourceListPage}
+              />
+
               <Route path="/k8s/cluster/:plural/~new" exact component={CreateResource} />
+              <Route
+                path="/cluster/:clusterName/k8s/cluster/:plural/~new"
+                exact
+                component={CreateResource}
+              />
+
               <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/cluster/:plural/:name"
+                component={ResourceDetailsPage}
+              />
+
               <LazyRoute
                 path="/k8s/ns/:ns/pods/:podName/containers/:name"
                 loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
               />
+              <LazyRoute
+                path="/cluster/:clusterName/k8s/ns/:ns/pods/:podName/containers/:name"
+                loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
+              />
+
               <Route path="/k8s/ns/:ns/:plural/~new" exact component={CreateResource} />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural/~new"
+                exact
+                component={CreateResource}
+              />
+
               <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural/:name"
+                component={ResourceDetailsPage}
+              />
+
               <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/ns/:ns/:plural"
+                exact
+                component={ResourceListPage}
+              />
 
               <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/all-namespaces/:plural"
+                exact
+                component={ResourceListPage}
+              />
+
               <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
+              <Route
+                path="/cluster/:clusterName/k8s/all-namespaces/:plural/:name"
+                component={ResourceDetailsPage}
+              />
+              {/* END of new links */}
 
               {inactivePluginPageRoutes}
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -204,9 +204,9 @@ class App_ extends React.PureComponent {
     );
 
     return (
-      <DetectCluster>
-        <DetectPerspective>
-          <DetectNamespace>
+      <DetectPerspective>
+        <DetectNamespace>
+          <DetectCluster>
             {contextProviderExtensions.reduce(
               (children, e) => (
                 <EnhancedProvider key={e.uid} {...e.properties}>
@@ -215,9 +215,9 @@ class App_ extends React.PureComponent {
               ),
               content,
             )}
-          </DetectNamespace>
-        </DetectPerspective>
-      </DetectCluster>
+          </DetectCluster>
+        </DetectNamespace>
+      </DetectPerspective>
     );
   }
 }

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -58,7 +58,7 @@ const NavHeader: React.FC<NavHeaderProps> = ({ onPerspectiveSelected }) => {
     dispatch(clearSSARFlags());
     dispatch(detectFeatures());
     const oldPath = window.location.pathname;
-    const newPath = formatNamespaceRoute(activeNamespace, oldPath, window.location, true);
+    const newPath = formatNamespaceRoute(activeNamespace, oldPath, window.location, true, cluster);
     if (newPath !== oldPath) {
       history.pushPath(newPath);
     }

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -29,9 +29,17 @@ export const namespacedPrefixes = [
   '/provisionedservices',
   '/search',
   '/status',
+  '/cluster/:cluster/k8s',
 ];
 
 export const stripBasePath = (path: string): string => path.replace(basePathPattern, '/');
+
+export const getCluster = (path: string): string => {
+  const strippedPath = stripBasePath(path);
+  const split = strippedPath.split('/').filter((x) => x);
+
+  return split[0] === 'cluster' ? split[1] : null;
+};
 
 export const getNamespace = (path: string): string => {
   path = stripBasePath(path);
@@ -46,6 +54,8 @@ export const getNamespace = (path: string): string => {
     ns = split[3];
   } else if (split[1] === 'ns' && split[2]) {
     ns = split[2];
+  } else if (split[0] === 'cluster' && split[3] === 'ns' && split[4]) {
+    ns = split[4];
   } else {
     return;
   }

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -27,11 +27,11 @@ export const resourcePathFromModel = (
   cluster?: string,
 ) => {
   const { plural, namespaced, crd } = model;
-  const activeCluster = cluster || getActiveCluster();
+  const targetCluster = cluster || getActiveCluster();
 
   let url = '';
-  if (activeCluster && isMultiClusterEnabled()) {
-    url += `/cluster/${activeCluster}`;
+  if (targetCluster && isMultiClusterEnabled()) {
+    url += `/cluster/${targetCluster}`;
   }
 
   url += '/k8s/';

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -3,7 +3,8 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import { FLAGS } from '@console/shared/src/constants';
-// import { getActiveCluster } from '@console/internal/actions/ui';
+import { getActiveCluster } from '@console/internal/actions/ui';
+import isMultiClusterEnabled from '@console/app/src/utils/isMultiClusterEnabled';
 
 import { ResourceIcon } from './resource-icon';
 import {
@@ -19,16 +20,19 @@ import { FlagsObject } from '../../reducers/features';
 
 const unknownKinds = new Set();
 
-// import { getActiveCluster } from '@console/internal/reducers/ui';
-
-export const resourcePathFromModel = (model: K8sKind, name?: string, namespace?: string) => {
+export const resourcePathFromModel = (
+  model: K8sKind,
+  name?: string,
+  namespace?: string,
+  cluster?: string,
+) => {
   const { plural, namespaced, crd } = model;
-  //  const activeCluster = getActiveCluster();
+  const activeCluster = cluster || getActiveCluster();
 
   let url = '';
-  // if (activeCluster) {
-  //   url += `/cluster/${activeCluster}`;
-  // }
+  if (activeCluster && isMultiClusterEnabled()) {
+    url += `/cluster/${activeCluster}`;
+  }
 
   url += '/k8s/';
 

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -2,8 +2,9 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
-
 import { FLAGS } from '@console/shared/src/constants';
+// import { getActiveCluster } from '@console/internal/actions/ui';
+
 import { ResourceIcon } from './resource-icon';
 import {
   modelFor,
@@ -18,10 +19,18 @@ import { FlagsObject } from '../../reducers/features';
 
 const unknownKinds = new Set();
 
+// import { getActiveCluster } from '@console/internal/reducers/ui';
+
 export const resourcePathFromModel = (model: K8sKind, name?: string, namespace?: string) => {
   const { plural, namespaced, crd } = model;
+  //  const activeCluster = getActiveCluster();
 
-  let url = '/k8s/';
+  let url = '';
+  // if (activeCluster) {
+  //   url += `/cluster/${activeCluster}`;
+  // }
+
+  url += '/k8s/';
 
   if (!namespaced) {
     url += 'cluster/';


### PR DESCRIPTION
If `isMultiClusterEnabled` is true, this will automatically add the cluster name to the URL string for selected routes.

The purpose of this PR is for discussion before merging and finally merging multi-cluster to the feature branch on openshift/console

I did have some concerns and will mark those in the code