### PR TITLE
Fix useTelemetry tests for releaseVersion-only behavior

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/useTelemetry.spec.ts
@@ -76,10 +76,10 @@ describe('getClusterProperties', () => {
     expect(getClusterProperties().consoleVersion).toBe('4.17.4');
   });
 
-  it('falls back to consoleVersion if releaseVersion is not set', () => {
+  it('returns undefined if releaseVersion is not set', () => {
     window.SERVER_FLAGS = { ...originServerFlags, consoleVersion: 'v6.0.6-23079-g6689498225' };
     delete window.SERVER_FLAGS.releaseVersion;
-    expect(getClusterProperties().consoleVersion).toBe('v6.0.6-23079-g6689498225');
+    expect(getClusterProperties().consoleVersion).toBe(undefined);
   });
 
   it('returns undefined when releaseVersion and consoleVersion are not set', () => {
@@ -173,7 +173,7 @@ describe('useTelemetry', () => {
   it('calls the listener with console version and clusterType when they are configured (x.y.z and OSD)', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
-      consoleVersion: 'x.y.z',
+      releaseVersion: 'x.y.z',
       telemetry: { CLUSTER_TYPE: 'OSD', STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE },
     };
     updateClusterPropertiesFromTests();
@@ -191,7 +191,7 @@ describe('useTelemetry', () => {
   it('calls the listener with the optional properties', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
-      consoleVersion: 'x.y.z',
+      releaseVersion: 'x.y.z',
       telemetry: { CLUSTER_TYPE: 'OSD', STATE: CLUSTER_TELEMETRY_ANALYTICS.ENFORCE },
     };
     updateClusterPropertiesFromTests();
@@ -211,7 +211,7 @@ describe('useTelemetry', () => {
   it('calls the listener with clusterType DEVSANDBOX when CLUSTER_TYPE is OSD and DEVSANDBOX is "true"', () => {
     window.SERVER_FLAGS = {
       ...originServerFlags,
-      consoleVersion: 'x.y.z',
+      releaseVersion: 'x.y.z',
       telemetry: {
         CLUSTER_TYPE: 'OSD',
         DEVSANDBOX: 'true',


### PR DESCRIPTION
## Summary
- Updates `useTelemetry.spec.ts` to fix 4 failing tests caused by removing the `consoleVersion` fallback
- The `getClusterProperties` fallback test now expects `undefined` when only `consoleVersion` is set (no `releaseVersion`)
- Three `useTelemetry` tests now use `releaseVersion` instead of `consoleVersion` in `SERVER_FLAGS` setup, matching the new behavior where `clusterProperties.consoleVersion` only reports `releaseVersion`

## Test plan
- [ ] CI `frontend` job passes with these test fixes
- [ ] No regressions in other telemetry-related tests